### PR TITLE
Fix calls to playTrack with only 1 parameter

### DIFF
--- a/device-handlers/cast-web/cast-web.groovy
+++ b/device-handlers/cast-web/cast-web.groovy
@@ -444,7 +444,7 @@ def off() {
 
 def speak(phrase) {
     //def sound = textToSpeech(phrase, true)
-    return playTrack( textToSpeech(phrase, true).uri )
+    return playTrack( textToSpeech(phrase, true).uri, 0 )
 }
 //AUDIO NOTIFICATION, TEXT
 def playText(message, level) {
@@ -472,9 +472,7 @@ def playTextAndRestore(message, level) {
 def playTrackAtVolume(String, number) {
     logger('info', "playTrackAtVolume" + String)
     
-    def url = "" + String;
-    if(number!=null) { setLevel(number); }
-    return playTrack(String)
+    return playTrack(String, number)
 }
 //AUDIO NOTIFICATION, TRACK
 def playTrack(uri, level) {


### PR DESCRIPTION
playTrackAtVolume() and Speak() weren't passing the "level" parameter to playTrack, preventing TTS and audio alerts from playing when triggered by SHM